### PR TITLE
refactor: merge await and confirmation flags

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -3,6 +3,10 @@
 
 // Rewrite argument --help to display format flag in help
 process.argv = process.argv.map(arg => arg === "--help" ? "-h" : arg);
+if(process.argv[2] == 'help') {
+    console.log("\x1b[31m›\x1b[0m   Error: command help not found");
+    process.exit(2);
+}
 
 require('@oclif/command').run()
 .then(require('@oclif/command/flush'))

--- a/src/commands/create-unik.ts
+++ b/src/commands/create-unik.ts
@@ -91,7 +91,7 @@ export class CreateUnikCommand extends WriteCommand {
         this.log(`Transaction in explorer: ${transactionUrl}`);
 
         /**
-         * Wait for the first transaction confirmation (2 blocktimes max)
+         * Wait for the first transaction confirmation
          */
         this.actionStart("Waiting for transaction confirmation");
         const transactionFromNetwork = await this.waitTransactionConfirmations(

--- a/src/commands/disclose-explicit-values.ts
+++ b/src/commands/disclose-explicit-values.ts
@@ -11,10 +11,8 @@ import { cli } from "cli-ux";
 import { BaseCommand } from "../baseCommand";
 import { Formater, OUTPUT_FORMAT } from "../formater";
 import {
-    awaitFlag,
     checkPassphraseFormat,
     checkUnikIdFormat,
-    confirmationsFlag,
     createDiscloseTransaction,
     explicitValueFlag,
     getPassphraseFromUser,
@@ -32,10 +30,8 @@ export class DiscloseExplicitValuesCommand extends WriteCommand {
     ];
 
     public static flags = {
-        ...WriteCommand.flags,
+        ...WriteCommand.getWriteCommandFlags(),
         ...passphraseFlag,
-        ...awaitFlag,
-        ...confirmationsFlag,
         ...unikidFlag("The UNIK token on which to disclose values"),
         ...explicitValueFlag("Array of explicit value to disclose, separated with a space.", true),
     };
@@ -98,8 +94,8 @@ export class DiscloseExplicitValuesCommand extends WriteCommand {
 
         const transactionFromNetwork = await this.sendAndWaitConfirmations(
             transactionStruct,
-            flags.await,
-            flags.confirmations,
+            flags["await-confirmation"],
+            1,
         );
 
         return await this.formatResult(transactionFromNetwork, transactionStruct.id);

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -3,14 +3,7 @@ import { ITransactionData } from "@uns/crypto";
 import { BaseCommand } from "../baseCommand";
 import { SendCommandHelper } from "../commandHelpers/send-helper";
 import { Formater, OUTPUT_FORMAT } from "../formater";
-import {
-    awaitFlag,
-    confirmationsFlag,
-    getWalletFromPassphrase,
-    passphraseFlag,
-    secondPassphraseFlag,
-    toSatoshi,
-} from "../utils";
+import { getWalletFromPassphrase, passphraseFlag, secondPassphraseFlag, toSatoshi } from "../utils";
 import { WriteCommand } from "../writeCommand";
 
 const feesIncludedFlagId = "fees-included";
@@ -44,8 +37,6 @@ export class SendCommand extends WriteCommand {
             description: "Specify that the fees must be deducted from the amount. By default the fees are paid on top.",
             default: false,
         }),
-        ...awaitFlag,
-        ...confirmationsFlag,
         sato: flags.boolean({
             description: "Specify that the provided amount is in sato-UNS, not in UNS",
             default: false,

--- a/src/commands/set-properties.ts
+++ b/src/commands/set-properties.ts
@@ -11,14 +11,14 @@ export class SetPropertiesCommand extends UpdatePropertiesCommand {
 
     public static examples = [
         `$ uns set-properties --network ${getNetworksListListForDescription()} --unkid {unikId}
-        --properties "{key}:{value}" --format {json|yaml} --verbose`,
+        --properties "{key1}:{value1}" "{key2}:{value2}" --format {json|yaml} --verbose`,
     ];
 
     public static flags = {
         ...UpdatePropertiesCommand.getUpdateCommandFlags(),
         properties: flags.string({
-            description: `Array of properties to set: "key1:value1"
-                "key3:" Sets "value1" to "key1" and empty string to "key3"`,
+            description: `List of key/value to set as UNIK properties: "key1:value1" "key2:value2"`,
+
             required: true,
             multiple: true,
         }),

--- a/src/updatePropertiesCommand.ts
+++ b/src/updatePropertiesCommand.ts
@@ -1,9 +1,7 @@
 import { CommandOutput } from "./formater";
 import {
-    awaitFlag,
     checkPassphraseFormat,
     checkUnikIdFormat,
-    confirmationsFlag,
     createNFTUpdateTransaction,
     getPassphraseFromUser,
     passphraseFlag,
@@ -16,8 +14,6 @@ export abstract class UpdateProperties extends WriteCommand {
         return {
             ...WriteCommand.getWriteCommandFlags(fees),
             ...unikidFlag("The UNIK token on which to update the properties."),
-            ...awaitFlag,
-            ...confirmationsFlag,
             ...passphraseFlag,
         };
     }
@@ -58,8 +54,8 @@ export abstract class UpdateProperties extends WriteCommand {
         const finalTransaction = await this.waitTransactionConfirmations(
             this.api.getBlockTime(),
             transactionStruct.id,
-            flags.await,
-            flags.confirmations,
+            flags["await-confirmation"],
+            1,
         );
         this.actionStop();
 

--- a/src/utils/flags-utils.ts
+++ b/src/utils/flags-utils.ts
@@ -16,20 +16,11 @@ export const secondPassphraseFlag = {
     }),
 };
 
-export const awaitFlag = {
-    await: flags.integer({
-        description: `Number of blocks to wait to get confirmed for the success. Default to 3.
-          0 for immediate return.
-          Needs to be strictly greater than --confirmation flag`,
+export const awaitConfirmationFlag = {
+    "await-confirmation": flags.integer({
+        description: `Maximum number of blocks to wait to get one confirmation of the transaction. Default to 3.
+          0 for immediate return.`,
         default: 3,
-    }),
-};
-
-export const confirmationsFlag = {
-    confirmations: flags.integer({
-        description:
-            "Number of confirmations to wait to get confirmed for the success. Default to 1.\n\t Needs to be strictly lower than --await flag",
-        default: 1,
     }),
 };
 

--- a/src/writeCommand.ts
+++ b/src/writeCommand.ts
@@ -1,7 +1,7 @@
 import { crypto, KeyPair } from "@uns/crypto";
 import { BaseCommand } from "./baseCommand";
 import { HttpNotFoundError } from "./errorHandler";
-import { feeFlag } from "./utils";
+import { awaitConfirmationFlag, feeFlag } from "./utils";
 
 export abstract class WriteCommand extends BaseCommand {
     public static flags = WriteCommand.getWriteCommandFlags();
@@ -9,6 +9,7 @@ export abstract class WriteCommand extends BaseCommand {
         return {
             ...BaseCommand.baseFlags,
             ...feeFlag(fees),
+            ...awaitConfirmationFlag,
         };
     }
 


### PR DESCRIPTION
merge await and confirmations flags
new flag: awaitConfirmation which wait for 1 confirmation in the 3 next blocks by default 
```
        description: `Maximum number of blocks to wait to get one confirmation of the transaction. Default to 3.
          0 for immediate return.`,