### PR TITLE
feat: validate transaction schema in sendTransaction

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { ITransactionData } from "@uns/crypto";
+import { ITransactionData, Transaction } from "@uns/crypto";
 import { getPropertyValue, PropertyValue, ResponseWithChainMeta } from "@uns/ts-sdk";
 import delay from "delay";
 import * as req from "request-promise";
@@ -23,6 +23,7 @@ export class UNSCLIAPI {
      * @param transaction
      */
     public async sendTransaction(transaction: ITransactionData): Promise<any> {
+        Transaction.validateTransactionData(transaction);
         const requestOptions = {
             body: {
                 transactions: [transaction],

--- a/test/__fixtures__/commands/create-unik.ts
+++ b/test/__fixtures__/commands/create-unik.ts
@@ -19,9 +19,9 @@ export const transaction = {
     version: 1,
     type: 11,
     network: 30,
-    fee: 100000000,
+    fee: "100000000",
     senderPublicKey: "020d5e36cce37494811c1a6d8c5e05f744f45990cbcc1274d16914e093a5061011",
-    amount: 0,
+    amount: "0",
     asset: {
         nft: {
             unik: {

--- a/test/commands/set-properties.test.ts
+++ b/test/commands/set-properties.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@oclif/test";
+const UNIK_ID = "51615becbd39ad96344919dffa7b972f293b0a3973b05145fd6d0a1a20cac169";
+const PASSPHRASE = "reveal front short spend enjoy label element text alert answer select bright";
+describe("set-properties command", () => {
+    describe("Exit cases", () => {
+        const tooLongValue =
+            "toolong1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+        test.stderr()
+            .command([
+                "set-properties",
+                "-n",
+                "devnet",
+                "--unikid",
+                UNIK_ID,
+                "--passphrase",
+                PASSPHRASE,
+                "--properties",
+                `tooLong:${tooLongValue}`,
+            ])
+            // tslint:disable-next-line:no-empty
+            .catch(_ => {})
+            .it("Should return too long property", ctx => {
+                expect(ctx.stderr).to.equal(
+                    "» :stop: Value of property tooLong exceed the maximum allowed size of 255 bytes.;\n",
+                );
+            });
+    });
+});


### PR DESCRIPTION
use schema validation before calling the transaction API.
